### PR TITLE
compress only the root directory

### DIFF
--- a/cli/modules-example/rabbitmq/.petra-config.yaml
+++ b/cli/modules-example/rabbitmq/.petra-config.yaml
@@ -1,7 +1,7 @@
 namespace: staging
 name: rabbitmq2
 provider: helm
-version: 0.0.6
+version: 0.0.12
 metadata:
   owner: Hyokil
   team: GCP


### PR DESCRIPTION
module.tar.gz must contain only files in the root module directory.

e.g.:
```
modules-example/rabbitmq/main.tf -> main.tf
modules-example/rabbitmq/outputs.tf -> outputs.tf

....
```